### PR TITLE
A couple of small changes

### DIFF
--- a/fixtest/fix/protocol.py
+++ b/fixtest/fix/protocol.py
@@ -133,6 +133,11 @@ class FIXProtocol(object):
         message[34] = self._send_seqno
         message[52] = format_time(send_time)
 
+        # apply any common fields
+        if 'common_fields' in self.link_config:
+            for tag, value in self.link_config['common_fields']:
+                message[tag] = value
+
         # verify required tags
         for tag in self.link_config['required_fields']:
             # these two tags are updated when generating the binary

--- a/fixtest/fix/protocol.py
+++ b/fixtest/fix/protocol.py
@@ -220,9 +220,9 @@ class FIXProtocol(object):
                 (now - self._testrequest_time).seconds > 2*self.heartbeat):
             raise FIXTimeoutError('testrequest response timeout')
 
-        # if heartbeat seconds have elapsed since the last time
+        # if heartbeat seconds/2 have elapsed since the last time
         # a message was sent, send a heartbeat
-        if (now - self._last_send_time).seconds > self.heartbeat:
+        if (now - self._last_send_time).seconds > (self.heartbeat/2):
             self.transport.send_message(
                 FIXMessage(source=[(35, FIX.HEARTBEAT),
                                    (49, self.link_config['sender_compid']),

--- a/fixtest/fix/transport.py
+++ b/fixtest/fix/transport.py
@@ -226,7 +226,7 @@ class FIXTransport(internet.protocol.Protocol):
             if self.lc_task is None:
                 self.lc_task = task.LoopingCall(self.on_timer_tick_received)
                 reactor.callFromThread(self.lc_task.start,
-                                       self.protocol.heartbeat,
+                                       1,
                                        now=False)
         else:
             if self.lc_task is not None:

--- a/fixtest/sample_config.py
+++ b/fixtest/sample_config.py
@@ -94,6 +94,8 @@ FIX_4_2 = {
 #   group_fields: A dictionary of fields that belong
 #       to a group. The key is the group ID field that maps
 #       to a list of IDs that belong to the group.
+#   common_fields: A list of tag/value tuples which will be added
+#       to every message sent
 #   max_length: The maximum length of message (Default: 2048)
 #
 #   FIX connection information:
@@ -132,5 +134,7 @@ CONNECTIONS = [
         'header_fields': FIX_4_2['header_fields'],
         'required_fields': FIX_4_2['required_fields'],
         'group_fields': FIX_4_2['group_fields'],
+        'common_fields':[(50, 'TAG50'),
+                         (142, 'GB'),],
     },
 ]


### PR DESCRIPTION
Hi there, 
Two changes:
1. Allow a list of tag/values to be defined in the config which are applied to all outgoing messages.
2. Change the heartbeat logic so that a client will actually send a heartbeat before the server initiates a TestRequest

Making these changes allowed my to complete a project using the fixtest framework. It would be great if you could accept these and make a new version available via pip.
